### PR TITLE
Main correction and suggesitons

### DIFF
--- a/abstar/abstar.py
+++ b/abstar/abstar.py
@@ -178,7 +178,6 @@ def validate_args(args):
 
 def make_directories(args):
     full_paths = []
-    print(args.data_dir)
     if args.data_dir and not os.path.exists(args.data_dir):
         _make_direc(args.data_dir, args)
     indir = args.input if args.input else os.path.join(args.data_dir, 'input')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ config = {
 	'author_email': 'briney@scripps.edu',
 	'version': '0.1.0',
 	'install_requires': [
-						 # 'abtools',
+						 'abtools',
 						 'biopython',
 						 'celery',
 						 'nwalign',


### PR DESCRIPTION
1. # !/usr/bin/python must be changed to #!/usr/bin/env python. The first selects the system default python, which may may not be the user preferred python. The env will use the users preferred python where the abstar libraries were installed to. For instance, anaconda python is probably not /usr/bin/python and thus the libaries are not in /usr/libs/python/site-packages
2. There are multile reinitializations of the logger. Since you declare logger under the setup_logging function, there is no need to do it anywhere else. Just made sure that that is the first funciton called in main, or **init** main
3. Added a check exists for data director, and create it if its not there.
4. Changed the init logger to after the make directories function. Since the logger uses the make dirs output, it should be created before initializaiton of the logger.
5. Instead of full namespace imports, only imported functions that were used in some of the bigger packages. i.e. from multiprocessing import Pool
6. Took out skbio for now. It didn't seem to be used anywhere
