### PR TITLE
Update output.py

### DIFF
--- a/abstar/utils/output.py
+++ b/abstar/utils/output.py
@@ -163,7 +163,7 @@ class AbstarResult(object):
                     'n1_nt': self.antibody.junction.n1_nt,
                     'd_nt': self.antibody.junction.d_nt,
                     'n2_nt': self.antibody.junction.n2_nt,
-                    'j_nt': self.antibody.junction.v_nt,
+                    'j_nt': self.antibody.junction.j_nt, #Change from 'self.antibody.junction.v_nt' to 'self.antibody.junction.j_nt'
 #                     'd_cdr3_pos': {'start': self.antibody.junction.d_start_position_nt,
 #                                    'end': self.antibody.junction.d_end_position_nt},
                     'd_dist_from_cdr3_start': self.antibody.junction.d_dist_from_cdr3_start_nt,
@@ -181,7 +181,7 @@ class AbstarResult(object):
         else:
             junc = {'v_nt': self.antibody.junction.v_nt,
                     'n_nt': self.antibody.junction.n_nt,
-                    'j_nt': self.antibody.junction.v_nt}
+                    'j_nt': self.antibody.junction.j_nt} #Change from 'self.antibody.junction.v_nt' to 'self.antibody.junction.j_nt'
 
         output = collections.OrderedDict([
             ('seq_id', self.antibody.id),


### PR DESCRIPTION
Change lines 166 and 184 to fix bug. The junction breakdown was giving as output the v_nt instead of the j_nt for the J gene nucleotides.